### PR TITLE
Fix Nan case on mobile

### DIFF
--- a/src/lib/PhotoswipeGallery.svelte
+++ b/src/lib/PhotoswipeGallery.svelte
@@ -24,7 +24,7 @@ let columns: any[] = [];
 let galleryWidth: number = 0;
 let columnCount: number = 0;
 
-$: columnCount = parseInt(galleryWidth / maxColumnWidth) ?? 1;
+$: columnCount = parseInt(galleryWidth / maxColumnWidth) || 1;
 $: columnCount && Draw();
 $: galleryStyle =
     "grid-template-columns: repeat(" +


### PR DESCRIPTION
The Nullish_coalescing operator used to calculate columnCount makes it 0 for small devices (mobiles) and breaks it to build the Columns array used to render the dom with svelte.
Replace it with a Or operator that converts any falsy expression and 0 in our case to 1 as well in order to correctly render the dom for small screens like on mobiles.